### PR TITLE
Increased minimum size of mainwindow to 1400 x 800

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -13,7 +13,7 @@
 
 <?import javafx.scene.text.Text?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         minWidth="800" minHeight="600" onCloseRequest="#handleExit">
+         minWidth="1400" minHeight="800" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/FreeTime_32.png" />
   </icons>


### PR DESCRIPTION
Now the Mainwindow will always fully display the timetable panel.